### PR TITLE
use karma-require 0.2 for karma 0.10.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "karma-firefox-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.3",
-    "karma-requirejs": "~0.1.0",
+    "karma-requirejs": "~0.2.0",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",
     "karma": "~0.10.2",


### PR DESCRIPTION
karma has updated its karma-require requirement, and `npm install` now fails. this makes installing work.
