### PR TITLE
explain how to install bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Requirements:
   node.js, bower
 
 1. Clone the repo
-2. Run `npm install`
-3. Run `bower install`
-4. Copy the images in dist/images/cards to app/images/cards
-5. Run `grunt server`
+1. Run `npm install`
+1. Run `npm install -g bower`
+1. Run `bower install`
+1. Copy the images in dist/images/cards to app/images/cards
+1. Run `grunt server`
 
 The server should now be up at `http://localhost:9000`
 


### PR DESCRIPTION
turns out the readme instructions don't work if you haven't already `npm install -g bower`ed
